### PR TITLE
Exclude discouraged_optional_collection rule for tests

### DIFF
--- a/swift/swiftlint.test.yml
+++ b/swift/swiftlint.test.yml
@@ -1,10 +1,10 @@
 disabled_rules:
+  - discouraged_optional_collection
   - explicit_acl
   - force_cast
   - force_try
   - force_unwrapping
   - implicitly_unwrapped_optional
-  - discouraged_optional_collection
 
 opt_in_rules:
   - nimble_operator

--- a/swift/swiftlint.test.yml
+++ b/swift/swiftlint.test.yml
@@ -4,6 +4,7 @@ disabled_rules:
   - force_try
   - force_unwrapping
   - implicitly_unwrapped_optional
+  - discouraged_optional_collection
 
 opt_in_rules:
   - nimble_operator


### PR DESCRIPTION
This PR excludes the SwiftLint `discouraged_optional_collection`-rule for tests.

Closes #51