### PR TITLE
Refactor attributes configuration to enforce attributes on the line above

### DIFF
--- a/swift/swiftlint.yml
+++ b/swift/swiftlint.yml
@@ -140,6 +140,7 @@ array_init:
   severity: error
 attributes:
   severity: error
+  always_on_same_line: []
 block_based_kvo:
   severity: error
 class_delegate_protocol:


### PR DESCRIPTION
This PR refactors the `attributes` configuration on `swiftlint.yml` to enforce that all attributes are required to be on the line above.

Closes: #55