### PR TITLE
Require `SwiftLint` v0.38.2

### DIFF
--- a/PickwareStyleGuide.podspec
+++ b/PickwareStyleGuide.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = '9.0'
     s.osx.deployment_target = '10.14'
     s.preserve_paths = 'swift/*.{swift,yml}'
-    s.dependency 'SwiftLint', '~> 0.36.0'
+    s.dependency 'SwiftLint', '~> 0.38.2'
 end


### PR DESCRIPTION
This PR updates the SwiftLint version to 0.38.2

Closes #52