### PR TITLE
Add optional_enum_case_matching and prefer_self_type_over_type_of_self rules to swiftLint.yml

### DIFF
--- a/swift/swiftlint.yml
+++ b/swift/swiftlint.yml
@@ -65,8 +65,10 @@ opt_in_rules:
   - multiline_parameters_brackets
   - no_extension_access_modifier
   - operator_usage_whitespace
+  - optional_enum_case_matching
   - overridden_super_call
   - override_in_extension
+  - prefer_self_type_over_type_of_self
   - prefixed_toplevel_constant
   - private_action
   - prohibited_super_call
@@ -299,9 +301,13 @@ operator_usage_whitespace:
   severity: error
 operator_whitespace:
   severity: error
+optional_enum_case_matching:
+  severity: error
 overridden_super_call:
   severity: error
 override_in_extension:
+  severity: error
+prefer_self_type_over_type_of_self:
   severity: error
 prefixed_toplevel_constant:
   severity: error


### PR DESCRIPTION
This PR adds `optional_enum_case_matching` and `prefer_self_type_over_type_of_self` rules to `swiftLint.yml`


---

### Closes

* Closes #60
* Closes #61