### PR TITLE
Bump phpcs to v3.5.8 to support php 7.3 and up

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": ">=5.4.0",
         "viison/composer-git-hooks-installer-plugin": "^1.3",
-        "squizlabs/php_codesniffer": "^3.2"
+        "squizlabs/php_codesniffer": "^3.5.8"
     },
     "extra": {
         "available-viison-git-hooks": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "72e0e593100feaa1d43f69b6a8b245c1",
+    "content-hash": "a3ec726194c0a3fe156cdb554815d614",
     "packages": [
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.2.2",
+            "version": "3.5.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "d7c00c3000ac0ce79c96fcbfef86b49a71158cd1"
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d7c00c3000ac0ce79c96fcbfef86b49a71158cd1",
-                "reference": "d7c00c3000ac0ce79c96fcbfef86b49a71158cd1",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
                 "shasum": ""
             },
             "require": {
@@ -27,7 +27,7 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "bin": [
                 "bin/phpcs",
@@ -50,24 +50,24 @@
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-12-19T21:44:46+00:00"
+            "time": "2020-10-23T02:01:07+00:00"
         },
         {
             "name": "viison/composer-git-hooks-installer-plugin",
             "version": "1.3.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/VIISON/composer-git-hooks-installer-plugin.git",
+                "url": "https://github.com/pickware/composer-git-hooks-installer-plugin.git",
                 "reference": "33091a2533fc480da0aefbaafe54f211c08a79b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/VIISON/composer-git-hooks-installer-plugin/zipball/33091a2533fc480da0aefbaafe54f211c08a79b2",
+                "url": "https://api.github.com/repos/pickware/composer-git-hooks-installer-plugin/zipball/33091a2533fc480da0aefbaafe54f211c08a79b2",
                 "reference": "33091a2533fc480da0aefbaafe54f211c08a79b2",
                 "shasum": ""
             },
@@ -102,5 +102,6 @@
     "platform": {
         "php": ">=5.4.0"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
Currently when the git pre commit and push hooks are executed with PHP 7.3 or higher they fail with a deprecation error of phpcs. This PR updates phpcs to v3.5.8 which fixes the deprecation errors.

Related to https://github.com/pickware/EverythingShopware/issues/50