### PR TITLE
Allow mixed casing in testdox words

### DIFF
--- a/php/php-codesniffer-standard/VIISON/Sniffs/Methods/UnitTestMethodNameSniff.php
+++ b/php/php-codesniffer-standard/VIISON/Sniffs/Methods/UnitTestMethodNameSniff.php
@@ -139,7 +139,8 @@ class UnitTestMethodNameSniff implements Sniff
 
     private function getExpectedMethodNameFromTestdox($testdox)
     {
-        $words = preg_split('/[^a-zA-Z0-9]/', $testdox);
+        $testdoxWithoutApostropheS = preg_replace('/\'s/', 's', $testdox);
+        $words = preg_split('/[^a-zA-Z0-9]/', $testdoxWithoutApostropheS);
         $methodName = 'test_';
         foreach ($words as $index => $word) {
             if (mb_strlen($word) === 0) {

--- a/php/php-codesniffer-standard/VIISON/Sniffs/Methods/UnitTestMethodNameSniff.php
+++ b/php/php-codesniffer-standard/VIISON/Sniffs/Methods/UnitTestMethodNameSniff.php
@@ -147,7 +147,13 @@ class UnitTestMethodNameSniff implements Sniff
             }
 
             $firstLetter = mb_substr($word, 0, 1);
-            $followingLetters = mb_substr(mb_strtolower($word), 1);
+
+            $isWordUppercasedAcronym = $word == mb_strtoupper($word);
+            if ($isWordUppercasedAcronym === true) {
+                $followingLetters = mb_substr(mb_strtolower($word), 1);
+            } else {
+                $followingLetters = mb_substr($word, 1);
+            }
 
             if ($index === 0) {
                 $methodName .= mb_strtolower($firstLetter) . $followingLetters;

--- a/php/php-codesniffer-standard/VIISON/Tests/Methods/UnitTestMethodNameUnitTest.inc
+++ b/php/php-codesniffer-standard/VIISON/Tests/Methods/UnitTestMethodNameUnitTest.inc
@@ -41,4 +41,12 @@ class UnitTestClass
     {
         // Implementation
     }
+
+    /**
+     * @testdox test exception's properties
+     */
+    public function test_notTestExceptionsProperties(): void
+    {
+        // Implementation
+    }
 }

--- a/php/php-codesniffer-standard/VIISON/Tests/Methods/UnitTestMethodNameUnitTest.inc
+++ b/php/php-codesniffer-standard/VIISON/Tests/Methods/UnitTestMethodNameUnitTest.inc
@@ -35,9 +35,9 @@ class UnitTestClass
     }
 
     /**
-     * @testdox some DAL acronym
+     * @testdox some PascalCasing to be preserved
      */
-    public function test_someDalAcronym(): void
+    public function test_notSomePascalCasingToBePreserved(): void
     {
         // Implementation
     }

--- a/php/php-codesniffer-standard/VIISON/Tests/Methods/UnitTestMethodNameUnitTest.inc.fixed
+++ b/php/php-codesniffer-standard/VIISON/Tests/Methods/UnitTestMethodNameUnitTest.inc.fixed
@@ -41,4 +41,12 @@ class UnitTestClass
     {
         // Implementation
     }
+
+    /**
+     * @testdox test exception's properties
+     */
+    public function test_testExceptionsProperties(): void
+    {
+        // Implementation
+    }
 }

--- a/php/php-codesniffer-standard/VIISON/Tests/Methods/UnitTestMethodNameUnitTest.inc.fixed
+++ b/php/php-codesniffer-standard/VIISON/Tests/Methods/UnitTestMethodNameUnitTest.inc.fixed
@@ -35,9 +35,9 @@ class UnitTestClass
     }
 
     /**
-     * @testdox some DAL acronym
+     * @testdox some PascalCasing to be preserved
      */
-    public function test_someDalAcronym(): void
+    public function test_somePascalCasingToBePreserved(): void
     {
         // Implementation
     }

--- a/php/php-codesniffer-standard/VIISON/Tests/Methods/UnitTestMethodNameUnitTest.php
+++ b/php/php-codesniffer-standard/VIISON/Tests/Methods/UnitTestMethodNameUnitTest.php
@@ -18,6 +18,7 @@ class UnitTestMethodNameUnitTest extends AbstractSniffUnitTest
                     24 => 1,
                     32 => 1,
                     40 => 1,
+                    48 => 1,
                 ];
             default:
                 return [];

--- a/php/php-codesniffer-standard/VIISON/Tests/Methods/UnitTestMethodNameUnitTest.php
+++ b/php/php-codesniffer-standard/VIISON/Tests/Methods/UnitTestMethodNameUnitTest.php
@@ -17,6 +17,7 @@ class UnitTestMethodNameUnitTest extends AbstractSniffUnitTest
                     16 => 1,
                     24 => 1,
                     32 => 1,
+                    40 => 1,
                 ];
             default:
                 return [];


### PR DESCRIPTION
This pr prevents the linter to lowercase all letters in a word if the word is not a acronym with all uppercased letters. Additionally, the linter is now prevented from uppercasing an apostrophe s.

E.g.

`test NamedException` will result in `testNamedException` instead of `testNamedexception`.
`test exception's handling` will result in `testExceptionsHandling`.