### PR TITLE
Don't uppercase testdox `'t` and allow testdox to start with special characters

### DIFF
--- a/php/php-codesniffer-standard/VIISON/Sniffs/Methods/UnitTestMethodNameSniff.php
+++ b/php/php-codesniffer-standard/VIISON/Sniffs/Methods/UnitTestMethodNameSniff.php
@@ -141,7 +141,7 @@ class UnitTestMethodNameSniff implements Sniff
     {
         $testdoxWithoutApostropheS = preg_replace('/\'([st])/', '$1', $testdox);
         $words = preg_split('/[^a-zA-Z0-9]/', $testdoxWithoutApostropheS);
-        $methodName = 'test_';
+        $methodName = '';
         foreach ($words as $index => $word) {
             if (mb_strlen($word) === 0) {
                 continue;
@@ -156,13 +156,13 @@ class UnitTestMethodNameSniff implements Sniff
                 $followingLetters = mb_substr($word, 1);
             }
 
-            if ($index === 0) {
+            if ($methodName === '') {
                 $methodName .= mb_strtolower($firstLetter) . $followingLetters;
             } else {
                 $methodName .= mb_strtoupper($firstLetter) . $followingLetters;
             }
         }
 
-        return $methodName;
+        return 'test_' . $methodName;
     }
 }

--- a/php/php-codesniffer-standard/VIISON/Sniffs/Methods/UnitTestMethodNameSniff.php
+++ b/php/php-codesniffer-standard/VIISON/Sniffs/Methods/UnitTestMethodNameSniff.php
@@ -139,7 +139,7 @@ class UnitTestMethodNameSniff implements Sniff
 
     private function getExpectedMethodNameFromTestdox($testdox)
     {
-        $testdoxWithoutApostropheS = preg_replace('/\'s/', 's', $testdox);
+        $testdoxWithoutApostropheS = preg_replace('/\'([st])/', '$1', $testdox);
         $words = preg_split('/[^a-zA-Z0-9]/', $testdoxWithoutApostropheS);
         $methodName = 'test_';
         foreach ($words as $index => $word) {

--- a/php/php-codesniffer-standard/VIISON/Tests/Methods/UnitTestMethodNameUnitTest.inc
+++ b/php/php-codesniffer-standard/VIISON/Tests/Methods/UnitTestMethodNameUnitTest.inc
@@ -57,4 +57,12 @@ class UnitTestClass
     {
         // Implementation
     }
+
+    /**
+     * @testdox ::comment is prefixed with special character
+     */
+    public function test_notCommentIsPrefixedWithSpecialCharacter(): void
+    {
+        // Implementation
+    }
 }

--- a/php/php-codesniffer-standard/VIISON/Tests/Methods/UnitTestMethodNameUnitTest.inc
+++ b/php/php-codesniffer-standard/VIISON/Tests/Methods/UnitTestMethodNameUnitTest.inc
@@ -49,4 +49,12 @@ class UnitTestClass
     {
         // Implementation
     }
+
+    /**
+     * @testdox don't do it
+     */
+    public function test_notDontDoIt(): void
+    {
+        // Implementation
+    }
 }

--- a/php/php-codesniffer-standard/VIISON/Tests/Methods/UnitTestMethodNameUnitTest.inc.fixed
+++ b/php/php-codesniffer-standard/VIISON/Tests/Methods/UnitTestMethodNameUnitTest.inc.fixed
@@ -49,4 +49,12 @@ class UnitTestClass
     {
         // Implementation
     }
+
+    /**
+     * @testdox don't do it
+     */
+    public function test_dontDoIt(): void
+    {
+        // Implementation
+    }
 }

--- a/php/php-codesniffer-standard/VIISON/Tests/Methods/UnitTestMethodNameUnitTest.inc.fixed
+++ b/php/php-codesniffer-standard/VIISON/Tests/Methods/UnitTestMethodNameUnitTest.inc.fixed
@@ -57,4 +57,12 @@ class UnitTestClass
     {
         // Implementation
     }
+
+    /**
+     * @testdox ::comment is prefixed with special character
+     */
+    public function test_commentIsPrefixedWithSpecialCharacter(): void
+    {
+        // Implementation
+    }
 }

--- a/php/php-codesniffer-standard/VIISON/Tests/Methods/UnitTestMethodNameUnitTest.php
+++ b/php/php-codesniffer-standard/VIISON/Tests/Methods/UnitTestMethodNameUnitTest.php
@@ -19,6 +19,7 @@ class UnitTestMethodNameUnitTest extends AbstractSniffUnitTest
                     32 => 1,
                     40 => 1,
                     48 => 1,
+                    56 => 1,
                 ];
             default:
                 return [];

--- a/php/php-codesniffer-standard/VIISON/Tests/Methods/UnitTestMethodNameUnitTest.php
+++ b/php/php-codesniffer-standard/VIISON/Tests/Methods/UnitTestMethodNameUnitTest.php
@@ -20,6 +20,7 @@ class UnitTestMethodNameUnitTest extends AbstractSniffUnitTest
                     40 => 1,
                     48 => 1,
                     56 => 1,
+                    64 => 1,
                 ];
             default:
                 return [];


### PR DESCRIPTION
This pr incorporates the issues from https://github.com/pickware/shopware-plugins/pull/1366.