### PR TITLE
Add sniff to ensure correct casing of enum cases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": ">=5.4.0",
         "viison/composer-git-hooks-installer-plugin": "^1.3",
-        "squizlabs/php_codesniffer": "^3.5.8"
+        "squizlabs/php_codesniffer": "^3.7.0"
     },
     "extra": {
         "available-viison-git-hooks": {
@@ -25,5 +25,10 @@
     "minimum-stability": "stable",
     "require-dev": {
         "phpunit/phpunit": "7.5.20"
+    },
+    "config": {
+        "allow-plugins": {
+            "viison/composer-git-hooks-installer-plugin": true
+        }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9b3f347d2eba55f789450fee3c13255b",
+    "content-hash": "3af9fdddb325c576e5895ed5d18f61e0",
     "packages": [
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.8",
+            "version": "3.8.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "14f5fff1e64118595db5408e946f3a22c75807f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
-                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/14f5fff1e64118595db5408e946f3a22c75807f7",
+                "reference": "14f5fff1e64118595db5408e946f3a22c75807f7",
                 "shasum": ""
             },
             "require": {
@@ -27,11 +27,11 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
             "bin": [
-                "bin/phpcs",
-                "bin/phpcbf"
+                "bin/phpcbf",
+                "bin/phpcs"
             ],
             "type": "library",
             "extra": {
@@ -46,16 +46,45 @@
             "authors": [
                 {
                     "name": "Greg Sherwood",
-                    "role": "lead"
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
-                "standards"
+                "standards",
+                "static analysis"
             ],
-            "time": "2020-10-23T02:01:07+00:00"
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-01-11T20:47:48+00:00"
         },
         {
             "name": "viison/composer-git-hooks-installer-plugin",
@@ -1685,5 +1714,5 @@
         "php": ">=5.4.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/php/php-codesniffer-standard/VIISON/Sniffs/Enum/EnumCaseSniff.php
+++ b/php/php-codesniffer-standard/VIISON/Sniffs/Enum/EnumCaseSniff.php
@@ -1,0 +1,33 @@
+<?php
+namespace VIISON\StyleGuide\PHPCS\Standards\VIISON\Sniffs\Enum;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class EnumCaseSniff implements Sniff
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function register()
+    {
+        return [
+            T_ENUM_CASE,
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        $enumName = $tokens[$stackPtr]['content'];
+
+        // Überprüfen Sie, ob der Enum-Name im UpperCamelCase geschrieben ist
+        if (!preg_match('/^[A-Z][a-zA-Z0-9]*$/', $enumName)) {
+            $error = 'Enum cases should be written in UpperCamelCase';
+            $phpcsFile->addError($error, $stackPtr, 'NotUpperCamelCase');
+        }
+    }
+}

--- a/php/php-codesniffer-standard/VIISON/Sniffs/Enum/EnumCaseSniff.php
+++ b/php/php-codesniffer-standard/VIISON/Sniffs/Enum/EnumCaseSniff.php
@@ -21,8 +21,12 @@ class EnumCaseSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
+        $enumNamePosition = $phpcsFile->findNext(T_STRING, $stackPtr);
+        if ($enumNamePosition === false) {
+            return;
+        }
         $tokens = $phpcsFile->getTokens();
-        $enumName = $tokens[$stackPtr]['content'];
+        $enumName = $tokens[$enumNamePosition]['content'];
 
         // Check whether the enum case is written in  UpperCamelCase
         if (!preg_match('/^[A-Z][a-zA-Z0-9]*$/', $enumName)) {

--- a/php/php-codesniffer-standard/VIISON/Sniffs/Enum/EnumCaseSniff.php
+++ b/php/php-codesniffer-standard/VIISON/Sniffs/Enum/EnumCaseSniff.php
@@ -29,7 +29,7 @@ class EnumCaseSniff implements Sniff
         $enumName = $tokens[$enumNamePosition]['content'];
 
         // Check whether the enum case is written in  UpperCamelCase
-        if (!preg_match('/^[A-Z][a-zA-Z0-9]*$/', $enumName)) {
+        if (!preg_match('/^((([A-Z][a-z0-9]+)((\d)|([A-Z0-9][a-z0-9]+))*([A-Z])?)|[A-Z])$/', $enumName)) {
             $error = 'Enum cases should be written in UpperCamelCase';
             $phpcsFile->addError($error, $stackPtr, 'NotUpperCamelCase');
         }

--- a/php/php-codesniffer-standard/VIISON/Sniffs/Enum/EnumCaseSniff.php
+++ b/php/php-codesniffer-standard/VIISON/Sniffs/Enum/EnumCaseSniff.php
@@ -29,7 +29,7 @@ class EnumCaseSniff implements Sniff
         $enumName = $tokens[$enumNamePosition]['content'];
 
         // Check whether the enum case is written in  UpperCamelCase
-        if (!preg_match('/^((([A-Z][a-z0-9]+)((\d)|([A-Z0-9][a-z0-9]+))*([A-Z])?)|[A-Z])$/', $enumName)) {
+        if (!preg_match('/^((([A-Z][a-z0-9]+)((\\d)|([A-Z0-9][a-z0-9]+))*([A-Z])?)|[A-Z])$/', $enumName)) {
             $error = 'Enum cases should be written in UpperCamelCase';
             $phpcsFile->addError($error, $stackPtr, 'NotUpperCamelCase');
         }

--- a/php/php-codesniffer-standard/VIISON/Sniffs/Enum/EnumCaseSniff.php
+++ b/php/php-codesniffer-standard/VIISON/Sniffs/Enum/EnumCaseSniff.php
@@ -24,7 +24,7 @@ class EnumCaseSniff implements Sniff
         $tokens = $phpcsFile->getTokens();
         $enumName = $tokens[$stackPtr]['content'];
 
-        // Überprüfen Sie, ob der Enum-Name im UpperCamelCase geschrieben ist
+        // Check whether the enum case is written in  UpperCamelCase
         if (!preg_match('/^[A-Z][a-zA-Z0-9]*$/', $enumName)) {
             $error = 'Enum cases should be written in UpperCamelCase';
             $phpcsFile->addError($error, $stackPtr, 'NotUpperCamelCase');


### PR DESCRIPTION
Add sniff to ensure correct casing of enum cases.

https://pickware.slack.com/archives/C47RBTFD0/p1696435332942839